### PR TITLE
Fixing a bug

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image } onError={(e)=>{e.target.onerror = null; e.target.src="placeholder.png"}}
+        src={require('../placeholder.png')}//{item.image } onError={(e)=>{e.target.onerror = null; e.target.src="placeholder.png"}}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image } onError={(e)=>{e.target.onerror = null; e.target.src="placeholder.png"}}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

Now the placeholder image is shown when image url is not provided for a product.
Fixed the bug

![image](https://user-images.githubusercontent.com/70193389/182407903-76e1dd30-526f-4934-ac15-2667de8d804a.png)


__
[![sema-logo](https://app.semasoftware.com/img/sema-tray-logo.gif)](https://semasoftware.com/gh) &nbsp;**Summary:** :hammer_and_wrench: This code needs a fix
